### PR TITLE
Using the alternate request syntax for a GET requires a method=GET qu…

### DIFF
--- a/test/v1_0_3/H.Communication2.1-StatementResource.js
+++ b/test/v1_0_3/H.Communication2.1-StatementResource.js
@@ -331,7 +331,7 @@ describe('Statement Resource Requirements (Communication 2.1)', () => {
 
     it('A GET request is defined as either a GET request or a POST request containing a GET request (Communication 2.1.2.s2.b3)', function (done) {
         request(helper.getEndpointAndAuth())
-            .post(helper.getEndpointStatements())
+            .post(helper.getEndpointStatements() + "?method=GET")
             .headers(helper.addAllHeaders({}))
             .form({limit: 1})
             .expect(200).end(function (err, res) {


### PR DESCRIPTION
…ery parameter.

Fixes issue #81 .