### PR TITLE
Idsfix

### DIFF
--- a/test/v1_0_3/H.Communication2.1-StatementResource.js
+++ b/test/v1_0_3/H.Communication2.1-StatementResource.js
@@ -1481,7 +1481,7 @@ StatementResult Object.
                         expect(stmts).to.be.an('array');
                         stmts.forEach(function(stmt) {
                             if (stmt.id === id) {
-                                expect(Object.keys(stmt.actor).length).to.eql(1);
+                                expect(Object.keys(stmt.actor).length).to.eql(2);
                                 expect(Object.keys(stmt.object.actor).length).to.eql(2);
                                 expect(Object.keys(stmt.object.object).length).to.eql(1);
                                 /*  Removed since spec 1.0.3 is SHOULD*
@@ -1489,6 +1489,7 @@ StatementResult Object.
                                 expect(Object.keys(stmt.object.verb).length).to.eql(1);
                                 */
                                 expect(stmt.actor.mbox).to.eql(agent.mbox);
+                                expect(stmt.actor.objectType).to.eql(agent.objectType);
                                 expect(stmt.verb.id).to.eql(verb1.id);
                                 expect(stmt.object.actor.mbox).to.eql(group.mbox);
                                 expect(stmt.object.actor.objectType).to.eql(group.objectType);

--- a/test/v1_0_3/H.Communication2.1-StatementResource.js
+++ b/test/v1_0_3/H.Communication2.1-StatementResource.js
@@ -1481,7 +1481,7 @@ StatementResult Object.
                         expect(stmts).to.be.an('array');
                         stmts.forEach(function(stmt) {
                             if (stmt.id === id) {
-                                expect(Object.keys(stmt.actor).length).to.eql(2);
+                                expect(Object.keys(stmt.actor).length).to.be.within(1, 2);
                                 expect(Object.keys(stmt.object.actor).length).to.eql(2);
                                 expect(Object.keys(stmt.object.object).length).to.eql(1);
                                 /*  Removed since spec 1.0.3 is SHOULD*
@@ -1489,7 +1489,9 @@ StatementResult Object.
                                 expect(Object.keys(stmt.object.verb).length).to.eql(1);
                                 */
                                 expect(stmt.actor.mbox).to.eql(agent.mbox);
-                                expect(stmt.actor.objectType).to.eql(agent.objectType);
+                                if (stmt.actor.objectType) {
+                                    expect(stmt.actor.objectType).to.eql(agent.objectType);
+                                }
                                 expect(stmt.verb.id).to.eql(verb1.id);
                                 expect(stmt.object.actor.mbox).to.eql(group.mbox);
                                 expect(stmt.object.actor.objectType).to.eql(group.objectType);


### PR DESCRIPTION
makes object type optional for actor when using parameter format ids.
see https://github.com/adlnet/lrs-conformance-test-suite/pull/124