### PR TITLE
Implement mocha grep invert

### DIFF
--- a/bin/console_runner.js
+++ b/bin/console_runner.js
@@ -29,6 +29,7 @@ program
     .option('-t, --auth_token_path [string]', 'Path to OAuth authorization token endpoint (relative to endpoint)')
     .option('-l, --authorization_path [string]', 'Path to OAuth user authorization endpoint (relative to endpoint)')
     .option('-g, --grep [string]', 'Only run tests that match the given pattern')
+    .option('-i, --invert', 'Invert the grep pattern match')
     .option('-b, --bail', 'Abort the battery if one test fails')
     .option('-d, --directory [value]', 'Specific directories of tests (as a comma seperated list with no spaces)', clean_dir, ['v1_0_3'])
     .option('-z, --errors', 'Results log of failing tests only')
@@ -46,6 +47,7 @@ var options = {
         auth_token_path: program.auth_token_path,
         authorization_path: program.authorization_path,
         grep: program.grep,
+        invert: program.invert,
         bail: program.bail,
         directory: program.directory,
 		errors: program.errors

--- a/bin/lrs-test.js
+++ b/bin/lrs-test.js
@@ -44,6 +44,7 @@
             /* See [RFC-3986](http://tools.ietf.org/html/rfc3986#page-17) */
             endpoint: Joi.string().regex(/^[a-zA-Z][a-zA-Z0-9+\.-]*:.+/, 'URI').required(),
             grep: Joi.string(),
+            invert: Joi.boolean(),
             optional: Joi.array().items(Joi.string().required()),
             basicAuth: Joi.any(true, false),
             oAuth1: Joi.any(true, false),
@@ -95,6 +96,7 @@
             authPass: _options.authPass,
             reporter: _options.reporter,
             grep: _options.grep,
+            invert: _options.invert,
             optional: _options.optional,
             bail: _options.bail,
             consumer_key: _options.consumer_key,
@@ -116,10 +118,14 @@
             reporter: processMessageReporter(process),
             timeout: '15000',
             grep: grep,
+            invert: options.invert,
             bail: options.bail
         });
 
         console.log("Grep is " + grep);
+        if (options.invert) {
+            console.log("Invert is " + options.invert);
+        }
         process.env.DIRECTORY = options.directory[0];
 
         //adds optional tests to the front in ascending order


### PR DESCRIPTION
Allows the use of the mocha grep invert functionality in the LRS conformance test suite.

This adds the ability to exclude tests from a test run. I could not get a not-ed (`^`) grep regex to work in order to achieve this.