### PR TITLE
401 Racing Auth Correction

### DIFF
--- a/test/v1_0_2/non_templating.js
+++ b/test/v1_0_2/non_templating.js
@@ -3747,9 +3747,7 @@ console.log('nonT test3 blah blah blah blah:', attachment, typeof(attachment), '
                     .headers(headers)
                     .end(function (err, res) {
 
-                        if (res.statusCode === 400 || res.statusCode === 401) {
-                            done();
-                        } else {
+                        if (res.statusCode !== 400 && res.statusCode !== 401) {
                             done("Response should have been either 401 or 400.");
                         }
 

--- a/test/v1_0_2/non_templating.js
+++ b/test/v1_0_2/non_templating.js
@@ -3733,25 +3733,31 @@ console.log('nonT test3 blah blah blah blah:', attachment, typeof(attachment), '
                 // If authorization is bad and everything else is fine, we'll expect a 401
                 let badAuthHeaders = helper.addAllHeaders({}, true);
 
+		badAuthHeaders["Authorization"] = 'Basic ' + new Buffer('RobCIsNot:AUserOnThisLRS123').toString('base64');
+		    
                 request(helper.getEndpointAndAuth())
                     .get(helper.getEndpointStatements())
-                    .headers(headers)
+                    .headers(badAuthHeaders)
                     .expect(401)
-                    .end();
-
-                // In the case of BOTH a bad header situation AND bad auth, the LRS can return either 401 or 400
-                badAuthHeaders["X-Experience-API-Version"] = "BAD";
-
-                request(helper.getEndpointAndAuth())
-                    .get(helper.getEndpointStatements())
-                    .headers(headers)
                     .end(function (err, res) {
 
-                        if (res.statusCode !== 400 && res.statusCode !== 401) {
-                            done("Response should have been either 401 or 400.");
-                        }
+                            // Allow a bad version after ensuring that 401 is from an incorrect auth
+                            badAuthHeaders["X-Experience-API-Version"] = "BAD";
 
-                    });
+                            request(helper.getEndpointAndAuth())
+                                .get(helper.getEndpointStatements())
+                                .headers(badAuthHeaders)
+                                .end(function (err, res) {
+
+                                    if (res.statusCode === 400 || res.statusCode === 401) {
+                                        done();
+                                    } else {
+                                        done("Response should have been either 401 or 400.");
+                                    }
+
+                                });
+
+                        });
             });
         }
 

--- a/test/v1_0_3/H.Communication4.0-Authentication.js
+++ b/test/v1_0_3/H.Communication4.0-Authentication.js
@@ -104,7 +104,7 @@
                         .headers(headers)
                         .end(function (err, res) {
 
-                            if (res.statusCode !== 400 || res.statusCode !== 401) {
+                            if (res.statusCode !== 400 && res.statusCode !== 401) {
                                 done("Response should have been either 401 or 400.");
                             }
 

--- a/test/v1_0_3/H.Communication4.0-Authentication.js
+++ b/test/v1_0_3/H.Communication4.0-Authentication.js
@@ -49,19 +49,23 @@
                         .headers(headers)
                         .json(data)
                         .expect(401)
-                        .end();
-
-                    // In the case of BOTH a bad header situation AND bad auth, the LRS can return either 401 or 400
-                    headers["X-Experience-API-Version"] = "BAD";
-
-                    request(helper.getEndpointAndAuth())
-                        .get(helper.getEndpointStatements())
-                        .headers(headers)
                         .end(function (err, res) {
 
-                            if (res.statusCode !== 400 && res.statusCode !== 401) {
-                                done("Response should have been either 401 or 400.");
-                            }
+                            // Allow a bad version after ensuring that 401 is from an incorrect auth
+                            headers["X-Experience-API-Version"] = "BAD";
+
+                            request(helper.getEndpointAndAuth())
+                                .get(helper.getEndpointStatements())
+                                .headers(headers)
+                                .end(function (err, res) {
+
+                                    if (res.statusCode === 400 || res.statusCode === 401) {
+                                        done();
+                                    } else {
+                                        done("Response should have been either 401 or 400.");
+                                    }
+
+                                });
 
                         });
                 }
@@ -94,19 +98,23 @@
                         .headers(headers)
                         .json(data)
                         .expect(401)
-                        .end();
-
-                    // Same as above
-                    headers["X-Experience-API-Version"] = "BAD";
-
-                    request(helper.getEndpointAndAuth())
-                        .get(helper.getEndpointStatements())
-                        .headers(headers)
                         .end(function (err, res) {
 
-                            if (res.statusCode !== 400 && res.statusCode !== 401) {
-                                done("Response should have been either 401 or 400.");
-                            }
+                            // Allow a bad version after ensuring that 401 is from an incorrect auth
+                            headers["X-Experience-API-Version"] = "BAD";
+
+                            request(helper.getEndpointAndAuth())
+                                .get(helper.getEndpointStatements())
+                                .headers(headers)
+                                .end(function (err, res) {
+
+                                    if (res.statusCode === 400 || res.statusCode === 401) {
+                                        done();
+                                    } else {
+                                        done("Response should have been either 401 or 400.");
+                                    }
+
+                                });
 
                         });
                 }

--- a/test/v1_0_3/H.Communication4.0-Authentication.js
+++ b/test/v1_0_3/H.Communication4.0-Authentication.js
@@ -59,9 +59,7 @@
                         .headers(headers)
                         .end(function (err, res) {
 
-                            if (res.statusCode === 400 || res.statusCode === 401) {
-                                done();
-                            } else {
+                            if (res.statusCode !== 400 && res.statusCode !== 401) {
                                 done("Response should have been either 401 or 400.");
                             }
 
@@ -106,9 +104,7 @@
                         .headers(headers)
                         .end(function (err, res) {
 
-                            if (res.statusCode === 400 || res.statusCode === 401) {
-                                done();
-                            } else {
+                            if (res.statusCode !== 400 || res.statusCode !== 401) {
                                 done("Response should have been either 401 or 400.");
                             }
 


### PR DESCRIPTION
Resolving an issue where an LRS responding to bad credentials without `401` would pass under a callback race condition.

Since this is such a straightforward update, I don't expect any issues with existing conformance at all, but will leave this up for a week.

**This will be merged along and reflected in https://lrstest.adlnet.gov/ on Friday 3/29.**

Thanks.