### PR TITLE
Optional Version Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ node bin/console_runner.js --help
 
     -h, --help                         output usage information
     -V, --version                      output the version number
+    -x, --xapiVersion [string]         🌟 New: Version of the xAPI spec to test against
     -e, --endpoint [url]               xAPI endpoint
     -u, --authUser [string]            Basic Auth Username
     -p, --authPassword [string]        Basic Auth Password

--- a/bin/console_runner.js
+++ b/bin/console_runner.js
@@ -19,7 +19,7 @@ function clean_dir(val, dir) {
 
 program
     .version('0.0.1')
-    .option('-x, --xapiVersion [string]', 'Version of the xAPI Spec to test')
+    .option('-x, --xapiVersion [string]', '🌟 New: Version of the xAPI spec to test against')
     .option('-e, --endpoint [url]', 'xAPI endpoint')
     .option('-u, --authUser [string]', 'Basic Auth Username')
     .option('-p, --authPassword [string]', 'Basic Auth Password')

--- a/bin/lrs-test.js
+++ b/bin/lrs-test.js
@@ -40,6 +40,7 @@
 
     function runTests(_options) {
         var optionsValidator = Joi.object({
+            xapiVersion: Joi.string(),
             directory: Joi.array().items(Joi.string().required()),
             /* See [RFC-3986](http://tools.ietf.org/html/rfc3986#page-17) */
             endpoint: Joi.string().regex(/^[a-zA-Z][a-zA-Z0-9+\.-]*:.+/, 'URI').required(),
@@ -130,7 +131,6 @@
         }
 
         console.log("directory is ", options.directory);
-
 
         process.env.LRS_ENDPOINT = options.endpoint;
         process.env.BASIC_AUTH_ENABLED = options.basicAuth;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "lrs-conformance-tests",
   "main": "./bin/console_runner.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha test/v1_0_2/*.js --reporter nyan",
+    "test": "node node_modules/mocha/bin/mocha test/v1_0_2/*.js --reporter nyan",
     "start": "node ./bin/console_runner.js"
   },
   "repository": {

--- a/specConfig.js
+++ b/specConfig.js
@@ -1,0 +1,9 @@
+module.exports = {
+
+    defaultVersion: "1.0.3",
+
+    specToFolder: {
+        "1.0.2": "v1_0_2",
+        "1.0.3": "v1_0_3"
+    }
+}


### PR DESCRIPTION
Added an argument to specify a version of the xAPI spec.  This (hopefully) removes the hard-coded 1.0.3 string dependence and was implemented to let LRS Frontend site users test the 2.0 spec in an exploratory fashion ahead of the 2.0 release.

Changes:
- Addition of an xAPI Version argument (`-x` or `--xapiVersion`) which will select the test directory matching the specified version
- Addition of a `specConfig.js` folder for mapping xAPI versions to their test directories
- Specifying both `--directory` and `--xapiVersion` will cause an exit, `--xapiVersion` is essentially wrapping the directory argument