### PR TITLE
[2.0.0]Timestamp UTC conversion test uses an invalid timestamp

### DIFF
--- a/test/v2_0/4.2.7-Additional-Requirements-for-Data-Types.js
+++ b/test/v2_0/4.2.7-Additional-Requirements-for-Data-Types.js
@@ -122,7 +122,7 @@ describe("(4.2.7) Additional Requirements for Data Types", function () {
     describe("Timestamps", function() {
 
         it ("checks if the LRS converts timestamps to UTC", async() => {
-            const dateEST = "2023-05-04T12:00-05:00";
+            const dateEST = "2023-05-04T12:00:00-05:00";
             const dateUTC = "2023-05-04T17:00:00.000Z";
 
             let id = helper.generateUUID();


### PR DESCRIPTION
Timestamp UTC conversion test uses an invalid timestamp, causing test to fail for LRS instances that validate the timestamp against RFC 3339 date-time format.

Fixes https://github.com/adlnet/lrs-conformance-test-suite/issues/261