### PR TITLE
[2.0.0] Concurrency > Header precondition failure tests should use a valid entity tag

### DIFF
--- a/test/v2_0/4.1.4-Concurrency.js
+++ b/test/v2_0/4.1.4-Concurrency.js
@@ -70,7 +70,7 @@ function runConcurrencyTestsForDocumentResource(resourceName, resourcePath, reso
                 
                 it("Should reject a PUT request with a 412 Precondition Failed when using an incorrect ETag", async() => {
 
-                    let incorrectTag = "1234";
+                    let incorrectTag = `"1234"`;
                     let incorrectResponse = await xapiRequests.putDocument(resourcePath, document, resourceParams, { "If-Match": incorrectTag });
 
                     expect(incorrectResponse.status).to.equal(412);
@@ -116,7 +116,7 @@ function runConcurrencyTestsForDocumentResource(resourceName, resourcePath, reso
                 
                 it("Should reject a POST request with a 412 Precondition Failed when using an incorrect ETag", async() => {
 
-                    let incorrectTag = "1234";
+                    let incorrectTag = `"1234"`;
                     let incorrectResponse = await xapiRequests.postDocument(resourcePath, document, resourceParams, { "If-Match": incorrectTag });
 
                     expect(incorrectResponse.status).to.equal(412);
@@ -158,7 +158,7 @@ function runConcurrencyTestsForDocumentResource(resourceName, resourcePath, reso
                 
                 it("Should reject a DELETE request with a 412 Precondition Failed when using an incorrect ETag", async() => {
 
-                    let incorrectTag = "1234";
+                    let incorrectTag = `"1234"`;
                     let incorrectResponse = await xapiRequests.deleteDocument(resourcePath, resourceParams, { "If-Match": incorrectTag });
 
                     expect(incorrectResponse.status).to.equal(412);


### PR DESCRIPTION
Fix for https://github.com/adlnet/lrs-conformance-test-suite/issues/264

Updating concurrency header precondition tests that require a 412 Precondition Failure response to use a valid entity tag per RFC 2616, otherwise an LRS may correctly respond with a 400 Bad Request.